### PR TITLE
Initial LLM abstraction layer to use directly and through the autogen.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,66 @@
+# LLM configuration
+
+This folder contains configuration files for LLMs to be used with `navigator-helpers`.
+
+## Config format
+Configuration is using `litellm`'s format, with an extension that allows tagging configs.
+Here's an example:
+```yaml
+- model_name: gretelai-gpt-llama3-1-8b
+  litellm_params:
+    model: gretelai/gpt-llama3-1-8b
+    api_key: os.environ/GRETEL_API_KEY
+    api_base: https://api.gretel.ai
+  tags:
+  # multiple tags are supported, so they can both: indicate LLM-type (llama3.1 8B) in this case AND logical grouping ("base" for base tasks)
+  - gretelai/gpt-llama3-1-8b
+  - base
+```
+
+### Usage
+
+Load configuration from a file and filter by a tag.
+```python
+from pathlib import Path
+from navigator_helpers.llms import init_llms
+
+registry = init_llms(Path("llm_config_prod.yaml"))
+llm_configs = registry.get_by_tag("base")
+```
+
+Using it directly through the `completion` API.
+```python
+from navigator_helpers.llms import LLMWrapper, str_to_message
+
+llm = LLMWrapper.from_llm_configs(llm_configs)
+llm.completion([str_to_message("What's synthetic data?")], temperature=0.5)
+```
+
+Using it with the `autogen` library.
+
+```python
+from navigator_helpers.llms.autogen import AutogenAdapter
+from autogen import AssistantAgent, UserProxyAgent
+
+adapter = AutogenAdapter(llm_configs)
+# Note: with how autogen's support for custom model works, we need to wrap this initialization.
+assistant = adapter.initialize_agent(
+    AssistantAgent("assistant", llm_config=adapter.create_llm_config())
+)
+user_proxy = UserProxyAgent("user_proxy")
+user_proxy.initiate_chat(assistant, message="What's synthetic data?")
+```
+
+## Notes
+High level:
+- Use `litellm` as the main abstraction over LLMs.
+- Create our custom wrapper, so we can swap LiteLLM if needed.
+  - Perhaps this will also be useful for our execution, as we may access LLMs differently there?
+- For simplicity - initially use `litellm`'s config.
+  - If needed, introduce some extensions (like e.g. `tags`, etc.)
+- When using with `autogen`, translate the config to `autogen`'s format.
+- Application code will only interact with LLMs through `tags`.
+  - Each tag may have a single or multiple LLMs configured.
+- LiteLLM router will be created after filtering.
+- Keys required to access the LLM is using pattern from litellm's config (e.g. `os.environ/AZURE_API_KEY`).
+- `llm_config_prod.yaml` is a config using prod Gretel Inference endpoint.

--- a/config/llm_config_prod.yaml
+++ b/config/llm_config_prod.yaml
@@ -1,0 +1,16 @@
+- model_name: gretelai-gpt-llama3-1-8b
+  litellm_params:
+    model: gretelai/gpt-llama3-1-8b
+    api_key: os.environ/GRETEL_API_KEY
+    api_base: https://api.gretel.ai
+  tags:
+  - gretelai/gpt-llama3-1-8b
+  - base
+
+- model_name: gretelai-mistral-nemo-2407
+  litellm_params:
+    model: gretelai/gpt-mistral-nemo-2407
+    api_key: os.environ/GRETEL_API_KEY
+    api_base: https://api.gretel.ai
+  tags:
+  - gretelai/gpt-mistral-nemo-2407

--- a/examples/llms/llm_calling_demo.py
+++ b/examples/llms/llm_calling_demo.py
@@ -1,0 +1,65 @@
+import argparse
+import logging
+
+from argparse import Namespace
+from pathlib import Path
+
+from autogen import AssistantAgent, UserProxyAgent
+
+from navigator_helpers.data_synthesis import logger
+from navigator_helpers.llms import init_llms, LLMConfig, LLMWrapper, str_to_message
+from navigator_helpers.llms.autogen import AutogenAdapter
+from navigator_helpers.logs import configure_logger
+
+
+def main(config_path: str) -> None:
+    llm_registry = init_llms(Path(config_path), fail_on_error=False)
+
+    # Filter configs by tag
+    llm_configs = list(llm_registry.get_by_tag("base"))
+
+    # Use it with autogen
+    run_autogen_example(llm_configs)
+
+    # Use it directly
+    run_direct_example(llm_configs)
+
+
+def run_autogen_example(llm_configs: list[LLMConfig]) -> None:
+    adapter = AutogenAdapter(llm_configs)
+    assistant = adapter.initialize_agent(
+        AssistantAgent("assistant", llm_config=adapter.create_llm_config())
+    )
+    user_proxy = UserProxyAgent(
+        "user_proxy", human_input_mode="NEVER", code_execution_config=False
+    )
+    result = user_proxy.initiate_chat(
+        assistant,
+        message="Write python code to print 'Hello World!'",
+    )
+    logger.info(f"Autogen result: {result}")
+
+
+def run_direct_example(llm_configs: list[LLMConfig]) -> None:
+    llm = LLMWrapper.from_llm_configs(llm_configs)
+    result = llm.completion(
+        [
+            str_to_message("You are an experienced Python developer.", role="system"),
+            str_to_message("Write python code to print 'Hello World!'"),
+        ]
+    )
+    logger.info(f"Direct LLM call result: {result}")
+
+
+def parse_arguments() -> Namespace:
+    parser = argparse.ArgumentParser(description="Run demo.")
+    parser.add_argument(
+        "--config", required=True, type=str, help="Path to the configuration file"
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    configure_logger(level=logging.INFO)
+    args = parse_arguments()
+    main(args.config)

--- a/navigator_helpers/llms/__init__.py
+++ b/navigator_helpers/llms/__init__.py
@@ -1,0 +1,2 @@
+from navigator_helpers.llms.base import init_llms, LLMConfig
+from navigator_helpers.llms.litellm import LLMWrapper, str_to_message

--- a/navigator_helpers/llms/autogen.py
+++ b/navigator_helpers/llms/autogen.py
@@ -1,0 +1,104 @@
+from typing import Any, Union
+
+from autogen import ConversableAgent, ModelClient
+from litellm import Router
+
+from navigator_helpers.llms import LLMConfig
+from navigator_helpers.llms.litellm import create_router, LLMWrapper
+
+
+class AutogenAdapter:
+    """
+    Adapts our LLM configuration to autogen's format.
+    """
+
+    def __init__(self, llm_configs: list[LLMConfig]):
+        self._llm_configs = llm_configs
+
+    def create_llm_config(self):
+        autogen_config = [
+            _to_autogen_config(llm_config) for llm_config in self._llm_configs
+        ]
+
+        agent_llm_config = {"config_list": autogen_config}
+        # Disable caching (as per https://microsoft.github.io/autogen/docs/topics/llm-caching/#disabling-cache)
+        agent_llm_config["cache_seed"] = None
+
+        return agent_llm_config
+
+    def _create_router(self) -> Router:
+        return create_router(self._llm_configs)
+
+    def initialize_agent(self, agent: ConversableAgent) -> ConversableAgent:
+        agent.register_model_client(
+            model_client_cls=LiteLLMClient, router=self._create_router()
+        )
+        return agent
+
+
+def _to_autogen_config(config: LLMConfig) -> dict[str, Any]:
+    """
+    See https://microsoft.github.io/autogen/docs/topics/llm_configuration/
+
+    ## Decisions
+
+    To simplify things for now, all the calls will go through LiteLLMClient.
+    - This way, we have control over all the traffic (for logging, etc.).
+    - Alternatively, for endpoints that are natively supported in autogen, we could directly use them (e.g. OpenAI, etc.)
+    """
+    return {
+        "model": config.model_name,
+        "model_client_cls": "LiteLLMClient",
+        "api_type": "litellm",
+        "params": config.params,
+    }
+
+
+class LiteLLMClient(ModelClient):
+    """
+    Compatibility layer between autogen and litellm.
+    """
+
+    def __init__(self, config: dict[str, Any], router: Router):
+        self._config = config
+        # TODO: Maybe use `config` to validate that router has that model?
+        self._router = router
+
+    def create(self, params: dict[str, Any]) -> ModelClient.ModelClientResponseProtocol:
+        model = params.get("model")
+        generation_params = params.get("params", {})
+        messages = params.get("messages", [])
+
+        llm = LLMWrapper(model, self._router)
+
+        response = llm.completion(messages, **generation_params)
+        # NOTE: `response` (type `ModelResponse`) from the litellm implements
+        # the `ModelClient.ModelClientResponseProtocol`.
+        return response
+
+    def message_retrieval(
+        self, response: ModelClient.ModelClientResponseProtocol
+    ) -> Union[list[str], list[ModelClient.ModelClientResponseProtocol.Choice.Message]]:
+        return [choice.message.content for choice in response.choices]
+
+    def cost(self, response: ModelClient.ModelClientResponseProtocol) -> float:
+        # TODO: Calculate cost based on response.usage
+        response.cost = 0
+        return 0
+
+    @staticmethod
+    def get_usage(response: ModelClient.ModelClientResponseProtocol) -> dict[str, Any]:
+        usage_dict = {}
+        if model := getattr(response, "model", None):
+            usage_dict["model"] = model
+
+        if hasattr(response, "usage"):
+            usage = response.usage
+            usage_dict.update(
+                {
+                    "prompt_tokens": usage.prompt_tokens,
+                    "completion_tokens": usage.completion_tokens,
+                    "total_tokens": usage.total_tokens,
+                }
+            )
+        return usage_dict

--- a/navigator_helpers/llms/base.py
+++ b/navigator_helpers/llms/base.py
@@ -1,0 +1,121 @@
+import logging
+import os
+
+from pathlib import Path
+from typing import Any, Callable, Iterator, Union
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class LLMConfig:
+    _litellm_control_params = {"model", "api_key", "base_url", "extra_headers"}
+
+    def __init__(self, config: dict[str, Any]):
+        self._config = config
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return self._config
+
+    @property
+    def model_name(self) -> str:
+        return self._config["model_name"]
+
+    @property
+    def params(self) -> dict[str, Any]:
+        params = self._config["litellm_params"]
+        return {
+            k: v for k, v in params.items() if k not in self._litellm_control_params
+        }
+
+
+class LLMRegistry:
+    def __init__(self, model_list: list[dict[str, Any]]):
+        self._model_list = model_list
+
+    def get_by_tag(self, tag: str) -> Iterator[LLMConfig]:
+        """
+        Get all LLMs that have a specific tag.
+        """
+        for model in self._model_list:
+            if tag in model.get("tags", []):
+                yield LLMConfig(model)
+
+    def filter(self, filters: dict[str, Any]):
+        """
+        Examples:
+            {"model": ["gpt-3.5-turbo"]}
+            {"tags": ["gretel_inference"]}
+        """
+
+
+def init_llms(
+    config: Union[list[dict[str, Any]], str, Path], *, fail_on_error: bool = True
+) -> LLMRegistry:
+    """
+    Initialize LLMs from a config file or config dict.
+    """
+    loaded_config = config
+
+    if isinstance(config, Path):
+        loaded_config = yaml.safe_load(config.read_text())
+
+    elif isinstance(config, str):
+        # TODO: check if it's S3 link, so we can fetch from there
+        loaded_config = yaml.safe_load(Path(config).read_text())
+
+    # `resolve_keys` modifies the config in place
+    resolve_keys(loaded_config, fail_on_error=fail_on_error)
+
+    return LLMRegistry(loaded_config)
+
+
+RESOLVE_MAX_LEVEL = 3
+
+
+def resolve_keys(
+    model_list: list[dict[str, Any]], *, fail_on_error: bool = True
+) -> None:
+    """
+    Note: It modifies the config in place!
+    """
+    resolvers = {
+        "os.environ": _resolve_os_environ,
+    }
+
+    for config in model_list:
+        _resolve_level(config, resolvers, 0, fail_on_error)
+
+
+def _resolve_os_environ(identifier: str) -> str:
+    value = os.environ.get(identifier)
+    if value is None:
+        raise ValueError(f"Environment variable {identifier!r} is not set")
+
+    logger.info(f"Resolved ENV: {identifier!r} to '{value[:4]}...'")
+    return value
+
+
+def _resolve_level(
+    current: dict[str, Any],
+    resolvers: dict[str, Callable[[str], str]],
+    level: int,
+    fail_on_error: bool = True,
+) -> None:
+    for key, value in current.items():
+        if isinstance(value, str) and value.startswith(tuple(resolvers.keys())):
+            try:
+                resolver, identifier = value.split("/")
+                current[key] = resolvers[resolver](identifier)
+            except ValueError:
+                if fail_on_error:
+                    raise
+                else:
+                    logger.warning(
+                        f"Failed to resolve key: {key!r} with value: {value!r}. Skipping, but using that model will fail!"
+                    )
+
+        elif isinstance(value, dict) and level < RESOLVE_MAX_LEVEL:
+            _resolve_level(value, resolvers, level + 1, fail_on_error=fail_on_error)

--- a/navigator_helpers/llms/gretel.py
+++ b/navigator_helpers/llms/gretel.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+
+from typing import Any
+
+from gretel_client import configure_session
+from gretel_client.inference_api.natural_language import NaturalLanguageInferenceAPI
+from litellm import CustomLLM
+from litellm.types.utils import Choices, Message, ModelResponse
+
+logger = logging.getLogger(__name__)
+
+
+class InferenceAPI(CustomLLM):
+    """
+    Adapter to use Gretel's Inference API as a LiteLLM model.
+    """
+
+    def completion(
+        self,
+        model: str,
+        messages: list,
+        optional_params: dict[str, Any] = None,
+        *args,
+        **kwargs,
+    ) -> ModelResponse:
+        backend_model = f"gretelai/{model}"
+        iapi = self._configure_inference_api(backend_model, kwargs)
+
+        supported_params = ["temperature", "top_p", "top_k", "max_tokens"]
+        generate_params = {
+            p: optional_params[p] for p in supported_params if p in optional_params
+        }
+
+        # Gretel Inference currently only supports a single string input, so we need to
+        # "flatten" the messages to a single string.
+
+        # NOTE: since this doesn't work the "native" prompt template
+        # (with special tokens, etc.) the performance of this will likely be lower than
+        # using the model directly.
+        inference_input = "\n\n".join(_message_to_str(message) for message in messages)
+        logger.debug(f"Calling Gretel Inference API with payload\n{inference_input}")
+
+        response = iapi.generate(inference_input, **generate_params)
+
+        # NOTE: response from Gretel Inference doesn't have information about the
+        # 'finish_reason', which means that it will always be 'stop', even if the
+        # inference reached the max tokens limit.
+        return ModelResponse(
+            choices=[Choices(message=Message(content=response, role="assistant"))],
+            model=backend_model,
+        )
+
+    def _configure_inference_api(
+        self, backend_model: str, kwargs: dict[str, Any]
+    ) -> NaturalLanguageInferenceAPI:
+        session_kwargs = {"validate": False}
+        if "api_key" in kwargs:
+            session_kwargs["api_key"] = kwargs["api_key"]
+        if "api_base" in kwargs:
+            # NOTE: endpoint cannot have a trailing slash!
+            session_kwargs["endpoint"] = kwargs["api_base"].rstrip("/")
+        gretel_session = configure_session(**session_kwargs)
+
+        return NaturalLanguageInferenceAPI(backend_model, session=gretel_session)
+
+
+def _message_to_str(message: dict[str, str]) -> str:
+    return message["role"].upper() + ":\n" + message["content"] + "\n---"

--- a/navigator_helpers/llms/litellm.py
+++ b/navigator_helpers/llms/litellm.py
@@ -1,0 +1,63 @@
+"""
+Why litellm?
+All the libraries that we use have support for litellm:
+- autogen
+- distilabel
+- langchain
+
+This way we can configure LLMs once and use them in any of the contexts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import litellm
+
+from litellm import Router
+from litellm.types.utils import ModelResponse
+from litellm.utils import custom_llm_setup
+
+from navigator_helpers.llms import LLMConfig
+from navigator_helpers.llms.gretel import InferenceAPI
+
+logger = logging.getLogger(__name__)
+
+
+def create_router(configs: list[LLMConfig]) -> Router:
+    model_list = [config.config for config in configs]
+
+    # TODO: this could be conditional and applied only if there is a config that uses IAPI
+    litellm.custom_provider_map = [
+        {"provider": "gretelai", "custom_handler": InferenceAPI()}
+    ]
+
+    # This let's litellm ingest that custom config
+    custom_llm_setup()
+
+    return Router(model_list)
+
+
+class LLMWrapper:
+    def from_llm_configs(llm_configs: list[LLMConfig]) -> LLMWrapper:
+        if not llm_configs:
+            raise ValueError("At least one LLM config is required")
+
+        router = create_router(llm_configs)
+        llm_config = llm_configs[0]
+        # TODO: This is a bit awkward with how we create the model_name.
+        #  Need to iterate on this a bit more.
+
+        return LLMWrapper(llm_config.model_name, router)
+
+    def __init__(self, model_name: str, router: Router):
+        self._model_name = model_name
+        self._router = router
+
+    def completion(self, messages: list[dict[str, str]], **kwargs) -> ModelResponse:
+        logger.debug(f"Calling {self._model_name} with messages: {messages}")
+        return self._router.completion(self._model_name, messages, **kwargs)
+
+
+def str_to_message(content: str, role: str = "user") -> dict[str, str]:
+    return {"content": content, "role": role}

--- a/navigator_helpers/logs.py
+++ b/navigator_helpers/logs.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+
+LOG_FORMAT = (
+    "%(asctime)s.%(msecs)03dZ "
+    "[%(process)d] - "
+    "%(levelname)s - "
+    "%(name)s - "
+    "%(message)s"
+)
+
+
+def configure_logger(*, level: int = logging.INFO) -> None:
+    formatter = logging.Formatter(LOG_FORMAT)
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+    root_logger.propagate = False
+
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ streamlit==1.35.0
 tqdm==4.66.4
 sqlfluff==3.1.0
 pyautogen[mistral,groq]==0.2.35
+litellm==1.43.9


### PR DESCRIPTION
### Goal
Have a single LLM configuration and be able to use it to work with any library/framework.

### Implementation
Right now, this implementation supports:
- Configuring any LLM backends that are supported by the [`litellm`](https://docs.litellm.ai/docs/providers).
  - Gretel Inference API (natural language ones) can be configured in the same way.
- This configuration can be used with `autogen` (it's automatically translated into the format that `autogen` uses).

### Try it out
```
python examples/llms/llm_calling_demo.py --config config/llm_config_prod.yaml
```

See [here](https://docs.google.com/document/d/1uJR0yPU4s23TMIm7nAgBaSCO_TsN3mXyA2J7_aBrnTI/edit) for how to configure this with different LLM backends!

To improve:
- Map exceptions from Gretel Inference to litellm (so e.g. auth errors are not retried).
- LiteLLM still prints some things, try to filter/quiet these.
- More ways of providing creds (secrets manager, etc.).
- Test/support wider LLM interface: function calling, structured outputs, etc.